### PR TITLE
GitHub OAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ You’ll need [io.js](https://iojs.org/en/index.html) and [MySQL](https://www.my
 1. Clone the repository (`git clone https://github.com/jsperf/jsperf.com.git`).
 2. Install dependencies (`npm install`).
 3. Get a [Browserscope.org](http://www.browserscope.org/) API key by signing in and going to [the settings page](http://www.browserscope.org/user/settings). (You'll need this in the next step)
-3. Setup database and other environment configuration (`npm run setup`).
+4. Register a new OAuth GitHub development application by going to [your settings page in github](https://github.com/settings/applications/new). Take note to copy the "Client ID" and "Client Secret". The callback URL is simply the root url of the application, e.g., "http://localhost:3000" 
+5. Setup database and other environment configuration (`npm run setup`).
 
 ### Running the server
 

--- a/config.js
+++ b/config.js
@@ -12,6 +12,21 @@ var config = {
   $meta: "jsPerf.com",
   scheme: process.env.SCHEME,
   domain: process.env.DOMAIN,
+  auth: {
+    oauth: {
+      secure: false,
+      github: {
+        secret: process.env.GITHUB_CLIENT_SECRET,
+        id: process.env.GITHUB_CLIENT_ID
+      },
+      cookiePass: process.env.BELL_COOKIE_PASS
+    },
+    session: {
+      pass: process.env.COOKIE_PASS,
+      name: "sid-jsperf",
+      secure: false
+    }
+  },
   port: {
     web: process.env.PORT
   },

--- a/config.js
+++ b/config.js
@@ -3,9 +3,11 @@
 require("dotenv").load();
 
 var Confidence = require("confidence");
+var _ = require("lodash");
 
 var criteria = {
-  env: process.env.NODE_ENV
+  env: process.env.NODE_ENV,
+  scheme: process.env.SCHEME
 };
 
 var config = {
@@ -14,7 +16,11 @@ var config = {
   domain: process.env.DOMAIN,
   auth: {
     oauth: {
-      secure: false,
+      secure: {
+        $filter: "scheme",
+        "https": true,
+        $default: false
+      },
       github: {
         secret: process.env.GITHUB_CLIENT_SECRET,
         id: process.env.GITHUB_CLIENT_ID
@@ -24,7 +30,11 @@ var config = {
     session: {
       pass: process.env.COOKIE_PASS,
       name: "sid-jsperf",
-      secure: false
+      secure: {
+        $filter: "scheme",
+        "https": true,
+        $default: false
+      }
     }
   },
   port: {
@@ -50,7 +60,8 @@ var config = {
 
 var store = new Confidence.Store(config);
 
-exports.get = function(key) {
+exports.get = function(key, overrides) {
+  _.assign(criteria, overrides);
   return store.get(key, criteria);
 };
 

--- a/manifest.js
+++ b/manifest.js
@@ -28,9 +28,9 @@ var manifest = {
     port: config.get("/port/web"),
     labels: ["web"]
   }],
-  plugins: {
-    "blipp": {},
-    "good": {
+  plugins: [
+    {"blipp": {}},
+    {"good": {
       reporters: [{
         reporter: "good-console",
         args: [{
@@ -38,8 +38,8 @@ var manifest = {
           response: "*"
         }]
       }]
-    },
-    "visionary": {
+    }},
+    {"visionary": {
       engines: {
         hbs: "handlebars"
       },
@@ -57,27 +57,31 @@ var manifest = {
         }),
         $default: visionaryContextDefault
       }
-    },
-    "yar": {
+    }},
+    {"yar": {
       cookieOptions: {
         // name: "jsPerf", FIXME
         password: config.get("/browserscope"),
         isSecure: !config.get("/debug"),
         isHttpOnly: true
       }
-    },
-    "./server/api/json": {},
-    "./server/api/jsonp": {},
-    "./server/web/browse": {},
-    "./server/web/contributors": {},
-    "./server/web/dart": {},
-    "./server/web/faq": {},
-    "./server/web/home": {},
-    "./server/web/popular": {},
-    "./server/web/public": {},
-    "./server/web/redirects": {},
-    "./server/web/sitemap/xml": {}
-  }
+    }},
+    {"bell": {}},
+    {"hapi-auth-cookie": {}},
+    {"./server/web/auth/strategies": {}},
+    {"./server/api/json": {}},
+    {"./server/api/jsonp": {}},
+    {"./server/web/browse": {}},
+    {"./server/web/contributors": {}},
+    {"./server/web/dart": {}},
+    {"./server/web/faq": {}},
+    {"./server/web/home": {}},
+    {"./server/web/popular": {}},
+    {"./server/web/public": {}},
+    {"./server/web/redirects": {}},
+    {"./server/web/sitemap/xml": {}},
+    {"./server/web/auth/github": {}}
+  ]
 };
 
 var store = new Confidence.Store(manifest);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/jsperf/jsperf.com",
   "dependencies": {
+    "bell": "^3.0.0",
     "blipp": "^2.0.1",
     "confidence": "^1.0.0",
     "dotenv": "^0.5.1",
@@ -35,6 +36,7 @@
     "good-console": "^4.1.0",
     "handlebars": "^3.0.0",
     "hapi": "^8.2.0",
+    "hapi-auth-cookie": "^3.0.1",
     "joi": "^5.1.0",
     "lodash": "^3.3.1",
     "mysql": "^2.5.5",

--- a/public/_css/main.src.css
+++ b/public/_css/main.src.css
@@ -150,6 +150,21 @@ button, .submit {
 	filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#ebebeb', EndColorStr='#b8b8b8');
 }
 
+.login {
+	padding: .35em .5em;
+	text-decoration: none;
+	cursor: pointer;
+	color: #000;
+	border: 1px solid #999;
+	background: #dadada;
+	background-image: -moz-linear-gradient(top, #ebebeb, #b8b8b8);
+	background-image: -o-linear-gradient(top, #ebebeb, #b8b8b8);
+	background-image: -webkit-gradient(linear, left top, left bottom, from(#ebebeb), to(#b8b8b8));
+	background-image: -webkit-linear-gradient(top, #ebebeb, #b8b8b8);
+	background-image: linear-gradient(top, #ebebeb, #b8b8b8);
+	filter: progid:DXImageTransform.Microsoft.gradient(startColorStr='#ebebeb', EndColorStr='#b8b8b8');
+}
+
 a:hover span, a:focus span, #comments .owner .meta a {
 	color: #fff;
 }

--- a/server/web/auth/github.js
+++ b/server/web/auth/github.js
@@ -1,0 +1,24 @@
+"use strict";
+
+exports.register = function(server, options, next) {
+
+  server.route({
+    method: "GET",
+    path: "/auth/github",
+    config: {
+      auth: "github",
+      handler: function loginHandler(request, reply) {
+        request.auth.session.clear();
+        request.auth.session.set(request.auth.credentials.profile);
+        return reply.redirect("/");
+      }
+    }
+  });
+
+  return next();
+
+};
+
+exports.register.attributes = {
+  name: "web/auth/github"
+};

--- a/server/web/auth/strategies.js
+++ b/server/web/auth/strategies.js
@@ -1,0 +1,27 @@
+"use strict";
+var config = require("../../../config");
+
+exports.register = function(server, options, next) {
+
+  server.auth.strategy("session", "cookie", {
+    password: config.get("/auth/session/pass"),
+    cookie: config.get("/auth/session/name"),
+    redirectTo: false,
+    isSecure: config.get("/auth/session/secure")
+  });
+
+  server.auth.strategy("github", "bell", {
+    provider: "github",
+    password: config.get("/auth/oauth/cookiePass"),
+    clientId: config.get("/auth/oauth/github/id"),
+    clientSecret: config.get("/auth/oauth/github/secret"),
+    isSecure: config.get("/auth/oauth/secure"),
+    location: config.get("/scheme") + "://" + config.get("/domain")
+  });
+
+  return next();
+};
+
+exports.register.attributes = {
+  name: "web/auth/strategies"
+};

--- a/server/web/home/index.hbs
+++ b/server/web/home/index.hbs
@@ -7,6 +7,7 @@
 <p>jsPerf aims to provide an easy way to create and share <a href="/browse" title="View some examples by browsing the jsPerf test cases">test cases</a>, comparing the performance of different JavaScript snippets by running benchmarks. For more information, see <a href="/faq" title="Frequently asked questions">the FAQ</a>.</p>
 
 <h2>Create a test case</h2>
+{{#if authorized}}
 
 {{error genError tag="p"}}
 
@@ -106,3 +107,6 @@
 
   </fieldset>
 </form>
+{{else}}
+   <a class="login" href="/auth/github"><i class="fa fa-github"></i> Login with GitHub to Create Test Cases</a>
+{{/if}}

--- a/server/web/home/index.js
+++ b/server/web/home/index.js
@@ -47,9 +47,22 @@ exports.register = function(server, options, next) {
   server.route({
     method: "GET",
     path: "/",
+    config: {
+      auth: {
+        mode: "try",
+        strategy: "session"
+      }
+    },
     handler: function(request, reply) {
+      var authorized = false;
+
+      if (request.auth.isAuthenticated) {
+        authorized = true;
+      }
+
       reply.view("home/index", _.assign(defaultContext, {
-        test: [defaultTest, defaultTest]
+        test: [defaultTest, defaultTest],
+        authorized: authorized
       }));
     }
   });
@@ -57,14 +70,16 @@ exports.register = function(server, options, next) {
   server.route({
     method: "POST",
     path: "/",
+    config: {
+      auth: "session"
+    },
     handler: function(request, reply) {
-
       var errResp = function(errObj) {
         if (errObj.message) {
           errObj.genError = errObj.message;
         }
 
-        reply.view("home/index", _.assign(defaultContext, request.payload, errObj)).code(400);
+        reply.view("home/index", _.assign(defaultContext, request.payload, {authorized: true}, errObj)).code(400);
       };
 
       var mediumText = Joi.string().allow("").max(mediumTextLength);

--- a/setup/index.js
+++ b/setup/index.js
@@ -68,6 +68,38 @@ var schema = {
           default: "jsperf_dev"
         }
       }
+    },
+    bell_cookie: {
+      properties:{
+        pass: {
+          description: "Cookie Password for Oauth",
+          required: true,
+          default: ""
+        }
+      }  
+    },
+    cookie: {
+      properties: {
+        pass: {
+          description: "Cookie Password",
+          required: true,
+          default: ""
+        }
+      }
+    },
+    github_client: {
+      properties: {
+        id: {
+          description: "GitHub Client ID",
+          required: true,
+          default: ""
+        },
+        secret: {
+          description: "GitHub Client Secret",
+          required: true,
+          default: ""
+        }
+      }
     }
   }
 };

--- a/templates/partials/header.hbs
+++ b/templates/partials/header.hbs
@@ -4,6 +4,7 @@
 
   {{#if home}}
     <meta name="description" content="A performance playground for JavaScript developers. Easily create and share test cases and run cross-browser benchmarks to find out which code snippet is most efficient.">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
   {{/if}}
 
   {{#if showAtom}}

--- a/test/config.js
+++ b/test/config.js
@@ -16,4 +16,27 @@ lab.experiment("Config", function() {
     Code.expect(Config.meta("/")).to.match(/jsPerf/i);
     done();
   });
+
+  lab.experiment("Cookies", function() {
+    lab.test("it secures the bell cookie if the scheme is https", function(done) {
+      Code.expect(Config.get("/auth/oauth/secure", {scheme: "https"})).to.equal(true);
+      done();
+    });
+
+    lab.test("it does not secures the bell cookie if the scheme is http", function(done) {
+      Code.expect(Config.get("/auth/oauth/secure", {scheme: "http"})).to.equal(false);
+      done();
+    });
+
+    lab.test("it does not secures the general cookie if the scheme is http", function(done) {
+      Code.expect(Config.get("/auth/session/secure", {scheme: "http"})).to.equal(false);
+      done();
+    });
+
+    lab.test("it secures the general cookie if the scheme is http", function(done) {
+      Code.expect(Config.get("/auth/session/secure", {scheme: "https"})).to.equal(true);
+      done();
+    });
+
+  });
 });

--- a/test/server/web/auth/github.js
+++ b/test/server/web/auth/github.js
@@ -1,0 +1,118 @@
+"use strict";
+
+var path = require("path");
+
+var Lab = require("lab");
+var Code = require("code");
+var Hapi = require("hapi");
+var proxyquire = require("proxyquire");
+
+var Config = require("../../../../config");
+
+var pagesServiceStub = {
+  checkIfSlugAvailable: function() {},
+  create: function() {}
+};
+
+var GitHubPlugin = proxyquire("../../../../server/web/auth/github", {
+  "../../services/pages": pagesServiceStub
+});
+
+var AuthPlugin = {
+  register: require("bell"),
+  options: {}
+};
+
+var AuthCookiePlugin = {
+  register: require("hapi-auth-cookie"),
+  options: {}
+};
+
+var lab = exports.lab = Lab.script();
+var request, server;
+
+lab.beforeEach(function(done) {
+  var plugins = [ GitHubPlugin ];
+  server = new Hapi.Server();
+
+  server.connection({
+    port: Config.get("/port/web")
+  });
+
+  server.register([ AuthCookiePlugin, AuthPlugin ], function(){
+
+    server.auth.strategy("session", "cookie", {
+      password: Config.get("/auth/session/pass"),
+      cookie: Config.get("/auth/session/name"),
+      redirectTo: false,
+      isSecure: Config.get("/auth/session/secure")
+    });
+
+    server.auth.strategy("github", "bell", {
+      provider: "github",
+      password: Config.get("/auth/oauth/cookiePass"),
+      clientId: Config.get("/auth/oauth/github/id"),
+      clientSecret: Config.get("/auth/oauth/github/secret"),
+      isSecure: Config.get("/auth/oauth/secure"),
+      location: Config.get("/scheme") + "://" + Config.get("/domain")
+    });
+  });
+
+  server.views({
+    engines: {
+      hbs: require("handlebars")
+    },
+    path: "./server/web",
+    layout: true,
+    helpersPath: "templates/helpers",
+    partialsPath: "templates/partials",
+    relativeTo: path.join(__dirname, "..", "..", "..", "..")
+  });
+
+  server.register(plugins, done);
+
+});
+
+lab.experiment("auth/GitHub", function() {
+
+  lab.experiment("GET", function() {
+
+    lab.beforeEach(function(done) {
+      request = {
+        method: "GET",
+        url: "/auth/github"
+      };
+
+      done();
+    });
+
+    lab.test("redirect to GitHub to auth", function(done) {
+      server.inject(request, function(response) {
+        Code.expect(response.statusCode).to.equal(302);
+        Code.expect(response.headers.location).to.include("github.com/login/oauth");
+
+        done();
+      });
+    });
+
+    lab.test("do not start session if not auth'd", function(done) {
+      server.inject(request, function(response) {
+        Code.expect(response.headers["set-cookie"][0]).to.not.include("sid-jsperf");
+
+        done();
+      });
+    });
+
+    lab.test("sets a user's public GH profile to a session cookie if auth'd", function(done) {
+      request.credentials = {profile: {"name": "test"}};
+
+      server.inject(request, function(response) {
+        Code.expect(response.headers["set-cookie"][0]).to.include("sid-jsperf");
+
+        done();
+      });
+    });
+
+  });
+
+});

--- a/test/server/web/auth/strategies.js
+++ b/test/server/web/auth/strategies.js
@@ -1,0 +1,94 @@
+"use strict";
+
+var Lab = require("lab");
+var Code = require("code");
+var Hapi = require("hapi");
+
+var Config = require("../../../../config");
+
+var AuthPlugin = {
+  register: require("bell"),
+  options: {}
+};
+
+var AuthCookiePlugin = {
+  register: require("hapi-auth-cookie"),
+  options: {}
+};
+
+var StrategiesPlugin = {
+  register: require("../../../../server/web/auth/strategies"),
+  options: {}
+};
+
+
+
+var GitHubRoutePlugin = {};
+    GitHubRoutePlugin.register = function(localserv, options, next) {
+    localserv.route({
+      method: "GET",
+      path: "/test/github",
+      config: {
+        auth: "github",
+         handler: function loginHandler(req, rep) {
+          return rep("works");
+        }
+      }
+    });
+    return next();
+  };
+
+  GitHubRoutePlugin.register.attributes = {
+  name: "web/auth/strategies/test/github"
+};
+var CookieRoutePlugin = {};
+    CookieRoutePlugin.register = function(localserv, options, next) {
+    localserv.route({
+      method: "GET",
+      path: "/test/cookie",
+      config: {
+        auth: "session",
+         handler: function loginHandler(req, rep) {
+          return rep("works");
+        }
+      }
+    });
+    return next();
+  };
+
+  CookieRoutePlugin.register.attributes = {
+  name: "web/auth/strategies/test/cookie"
+};
+
+
+var plugins = [ StrategiesPlugin, CookieRoutePlugin, GitHubRoutePlugin ];
+var lab = exports.lab = Lab.script();
+var server;
+
+lab.beforeEach(function(done) {
+  server = new Hapi.Server();
+
+  server.connection({
+    port: Config.get("/port/web")
+  });
+
+  server.register([ AuthCookiePlugin, AuthPlugin ], function(){
+    server.register(plugins, done);
+  });
+});
+
+lab.experiment("strategies", function() {
+
+  lab.experiment("github strategy", function() {
+
+    lab.test("auth to 200 if all is good", function(done) {
+      Code.expect(function () {
+        server.inject("/test/cookie", function() {
+          done();
+        });
+      }).to.not.throw();
+    });
+
+  });
+
+});


### PR DESCRIPTION
Addresses #19 

* Migrate manifest to use array instead of object to specify plugin o…rder (explicit order needed for auth plugins)
* Add bell `^3.0.0`
* Add hapi-auth-cookie `^3.0.1`
* Add new text to let user know they need to login first (currently starting with just GitHub)
* New auth strategies for Bell (Github)  - 'github' and Hapi-Auth-Cookie - 'session'
* Update tests authorization