### PR TITLE
set the charset to utf8mb4 instead of utf8

### DIFF
--- a/setup/sql/create_comments.sql
+++ b/setup/sql/create_comments.sql
@@ -9,4 +9,4 @@ CREATE TABLE IF NOT EXISTS `comments` (
   `published` datetime NOT NULL,
   PRIMARY KEY (`id`),
   KEY `pageID` (`pageID`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=0;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=0;

--- a/setup/sql/create_pages.sql
+++ b/setup/sql/create_pages.sql
@@ -21,4 +21,4 @@ CREATE TABLE IF NOT EXISTS `pages` (
   KEY `updated` (`updated`),
   KEY `author` (`author`),
   KEY `visible` (`visible`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=0;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=0;

--- a/setup/sql/create_tests.sql
+++ b/setup/sql/create_tests.sql
@@ -6,4 +6,4 @@ CREATE TABLE IF NOT EXISTS `tests` (
   `defer` enum('y','n') COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'n',
   PRIMARY KEY (`testID`),
   KEY `pageID` (`pageID`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=0;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci AUTO_INCREMENT=0;


### PR DESCRIPTION
Fixes "Error: ER_COLLATION_CHARSET_MISMATCH: COLLATION 'utf8mb4_unicode_ci' is not valid for CHARACTER SET 'utf8'"

Mac OS X
MySQL 5.7.10 (homebrew)