### PR TITLE
refactor tests to not be environment dependent

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -66,7 +66,20 @@ var manifest = {
     }},
     {'bell': {}},
     {'hapi-auth-cookie': {}},
-    {'./server/web/auth/strategies': {}},
+    {'./server/web/auth/strategies': {
+      session: {
+        password: config.get('/auth/session/pass'),
+        cookie: config.get('/auth/session/name'),
+        isSecure: config.get('/auth/session/secure')
+      },
+      oauth: {
+        password: config.get('/auth/oauth/cookiePass'),
+        clientId: config.get('/auth/oauth/github/id'),
+        clientSecret: config.get('/auth/oauth/github/secret'),
+        isSecure: config.get('/auth/oauth/secure'),
+        location: config.get('/scheme') + '://' + config.get('/domain')
+      }
+    }},
     {'./server/api/json': {}},
     {'./server/api/jsonp': {}},
     {'./server/web/auth/github': {}},

--- a/server/web/auth/strategies.js
+++ b/server/web/auth/strategies.js
@@ -1,20 +1,20 @@
-var config = require('../../../config');
-
 exports.register = function (server, options, next) {
+  server.log(['debug'], 'registering auth strategies');
+
   server.auth.strategy('session', 'cookie', {
-    password: config.get('/auth/session/pass'),
-    cookie: config.get('/auth/session/name'),
+    password: options.session.password,
+    cookie: options.session.cookie,
     redirectTo: false,
-    isSecure: config.get('/auth/session/secure')
+    isSecure: options.session.isSecure
   });
 
   server.auth.strategy('github', 'bell', {
     provider: 'github',
-    password: config.get('/auth/oauth/cookiePass'),
-    clientId: config.get('/auth/oauth/github/id'),
-    clientSecret: config.get('/auth/oauth/github/secret'),
-    isSecure: config.get('/auth/oauth/secure'),
-    location: config.get('/scheme') + '://' + config.get('/domain')
+    password: options.oauth.password,
+    clientId: options.oauth.clientId,
+    clientSecret: options.oauth.clientSecret,
+    isSecure: options.oauth.isSecure,
+    location: options.oauth.location
   });
 
   return next();

--- a/test/config.js
+++ b/test/config.js
@@ -1,6 +1,11 @@
 var Lab = require('lab');
 var Code = require('code');
-var Config = require('../config');
+var Proxyquire = require('proxyquire');
+var Config = Proxyquire('../config', {
+  './lib/config': {
+    normalizeDomain: function () {}
+  }
+});
 
 var lab = exports.lab = Lab.script();
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,12 +1,18 @@
 var Code = require('code');
 var Lab = require('lab');
-var composer = require('../index');
+var Proxyquire = require('proxyquire');
+
+var Composer = Proxyquire('../index', {
+  './manifest': {
+    get: function () { return {}; }
+  }
+});
 
 var lab = exports.lab = Lab.script();
 
 lab.experiment('Index', function () {
   lab.test('it composes a server', function (done) {
-    composer(function (err, server) {
+    Composer(function (err, server) {
       Code.expect(server).to.be.an.object();
 
       done(err);

--- a/test/server/web/auth/github.js
+++ b/test/server/web/auth/github.js
@@ -1,75 +1,45 @@
-var path = require('path');
-
 var Lab = require('lab');
 var Code = require('code');
 var Hapi = require('hapi');
-var proxyquire = require('proxyquire');
 
-var Config = require('../../../../config');
-
-var pagesServiceStub = {
-  checkIfSlugAvailable: function () {},
-  create: function () {}
-};
-
-var GitHubPlugin = proxyquire('../../../../server/web/auth/github', {
-  '../../services/pages': pagesServiceStub
-});
-
-var AuthPlugin = {
-  register: require('bell'),
-  options: {}
-};
-
-var AuthCookiePlugin = {
-  register: require('hapi-auth-cookie'),
-  options: {}
-};
+var GitHubPlugin = require('../../../../server/web/auth/github');
 
 var lab = exports.lab = Lab.script();
 var request, server;
 
-lab.beforeEach(function (done) {
-  var plugins = [ GitHubPlugin ];
-  server = new Hapi.Server();
+var MockAuthGitHub = {
+  register: function (server, options, next) {
+    server.auth.scheme('MockGitHub', function (s, o) {
+      return {
+        authenticate: function (request, reply) {}
+      };
+    });
 
-  server.connection({
-    port: Config.get('/port/web')
-  });
-
-  server.register([ AuthCookiePlugin, AuthPlugin ], function () {
+    server.auth.strategy('github', 'MockGitHub');
     server.auth.strategy('session', 'cookie', {
-      password: Config.get('/auth/session/pass'),
-      cookie: Config.get('/auth/session/name'),
-      redirectTo: false,
-      isSecure: Config.get('/auth/session/secure')
+      password: 'testing'
     });
 
-    server.auth.strategy('github', 'bell', {
-      provider: 'github',
-      password: Config.get('/auth/oauth/cookiePass'),
-      clientId: Config.get('/auth/oauth/github/id'),
-      clientSecret: Config.get('/auth/oauth/github/secret'),
-      isSecure: Config.get('/auth/oauth/secure'),
-      location: Config.get('/scheme') + '://' + Config.get('/domain')
-    });
-  });
-
-  server.views({
-    engines: {
-      hbs: require('handlebars')
-    },
-    path: './server/web',
-    layout: true,
-    helpersPath: 'templates/helpers',
-    partialsPath: 'templates/partials',
-    relativeTo: path.join(__dirname, '..', '..', '..', '..')
-  });
-
-  server.register(plugins, done);
-});
+    next();
+  }
+};
+MockAuthGitHub.register.attributes = {
+  name: 'github'
+};
 
 lab.experiment('auth/GitHub', function () {
+  lab.beforeEach(function (done) {
+    server = new Hapi.Server();
+
+    server.connection();
+
+    server.register([
+      require('hapi-auth-cookie'),
+      MockAuthGitHub,
+      GitHubPlugin
+    ], done);
+  });
+
   lab.experiment('GET', function () {
     lab.beforeEach(function (done) {
       request = {
@@ -80,28 +50,11 @@ lab.experiment('auth/GitHub', function () {
       done();
     });
 
-    lab.test('redirect to GitHub to auth', function (done) {
-      server.inject(request, function (response) {
-        Code.expect(response.statusCode).to.equal(302);
-        Code.expect(response.headers.location).to.include('github.com/login/oauth');
-
-        done();
-      });
-    });
-
-    lab.test('do not start session if not auth’d', function (done) {
-      server.inject(request, function (response) {
-        Code.expect(response.headers['set-cookie'][0]).to.not.include('sid-jsperf');
-
-        done();
-      });
-    });
-
-    lab.test('sets a user’s public GH profile to a session cookie if auth’d', function (done) {
+    lab.test('sets auth credentials profile to session and redirects', function (done) {
       request.credentials = {profile: {'name': 'test'}};
 
       server.inject(request, function (response) {
-        Code.expect(response.headers['set-cookie'][0]).to.include('sid-jsperf');
+        Code.expect(response.statusCode).to.equal(302);
 
         done();
       });

--- a/test/server/web/auth/strategies.js
+++ b/test/server/web/auth/strategies.js
@@ -1,87 +1,37 @@
 var Lab = require('lab');
-var Code = require('code');
 var Hapi = require('hapi');
-
-var Config = require('../../../../config');
-
-var AuthPlugin = {
-  register: require('bell'),
-  options: {}
-};
-
-var AuthCookiePlugin = {
-  register: require('hapi-auth-cookie'),
-  options: {}
-};
 
 var StrategiesPlugin = {
   register: require('../../../../server/web/auth/strategies'),
-  options: {}
-};
-
-var GitHubRoutePlugin = {};
-GitHubRoutePlugin.register = function (localserv, options, next) {
-  localserv.route({
-    method: 'GET',
-    path: '/test/github',
-    config: {
-      auth: 'github',
-      handler: function (req, rep) {
-        return rep('works');
-      }
+  options: {
+    session: {
+      password: 'testing',
+      cookie: 'jsperf',
+      isSecure: true
+    },
+    oauth: {
+      password: 'test1',
+      clientId: 'fromGH',
+      clientSecret: 's3cr3t',
+      isSecure: true,
+      location: 'http://localhost'
     }
-  });
-
-  return next();
+  }
 };
 
-GitHubRoutePlugin.register.attributes = {
-  name: 'web/auth/strategies/test/github'
-};
-
-var CookieRoutePlugin = {};
-CookieRoutePlugin.register = function (localserv, options, next) {
-  localserv.route({
-    method: 'GET',
-    path: '/test/cookie',
-    config: {
-      auth: 'session',
-      handler: function (req, rep) {
-        return rep('works');
-      }
-    }
-  });
-  return next();
-};
-
-CookieRoutePlugin.register.attributes = {
-  name: 'web/auth/strategies/test/cookie'
-};
-
-var plugins = [ StrategiesPlugin, CookieRoutePlugin, GitHubRoutePlugin ];
 var lab = exports.lab = Lab.script();
 var server;
 
-lab.beforeEach(function (done) {
-  server = new Hapi.Server();
-
-  server.connection({
-    port: Config.get('/port/web')
-  });
-
-  server.register([ AuthCookiePlugin, AuthPlugin ], function () {
-    server.register(plugins, done);
-  });
-});
-
 lab.experiment('strategies', function () {
-  lab.experiment('github strategy', function () {
-    lab.test('auth to 200 if all is good', function (done) {
-      Code.expect(function () {
-        server.inject('/test/cookie', function () {
-          done();
-        });
-      }).to.not.throw();
-    });
+  lab.test('registers auth strategies', function (done) {
+    server = new Hapi.Server();
+
+    server.connection();
+
+    server.register([
+      require('hapi-auth-cookie'),
+      require('bell'),
+      StrategiesPlugin
+    ], done);
   });
 });


### PR DESCRIPTION
attempts to fix #105 and unblock #102, #103, and #104 

currently, forked pull requests fail on travis because they don't get access to environment variables. this makes it harder to contribute and thus slows progress. I refactored the tests that were depending on environment variables and would like to remove the following from travis:

- `GITHUB_CLIENT_SECRET`
- `GITHUB_CLIENT_ID`
- `BELL_COOKIE_PASS`
- `COOKIE_PASS`
- `DOMAIN`
- `ADMIN_EMAIL`
- `BROWSERSCOPE`
- `SCHEME`
- `MYSQL_PASSWORD`

you can test this locally by moving your `.env` file to something like `.env.bak` and then run `npm test`. admittedly, this makes these tests more "unit" ("this block of code works as expected") and less "integration" ("the authentication flow of using github works like so")
