### PR TITLE
create nginx pid file when image is built, minor dev improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 2. Create a Data Volume Container to persist data: `docker create -v /var/lib/mysql --name data-jsperf-mysql mysql /bin/true`
 3. After completing the "Compose" steps below, setup database tables with: `docker-compose run web node /code/setup/tables`
 
+<sub>NOTE: see [Gotchas](#gotchas) if you plan on running the server behind a load balancer.</sub>
+
 ##### Compose
 
 `docker-compose.yml` orchestrates a load balancer (nginx), the app (this node project), and a database (mysql) with some additional services to help with continuous deployment. To start everything up, run: `MYSQL_PASSWORD=$MYSQL_PASSWORD docker-compose up`. Pressing `ctrl+c` or sending a similar interruption will stop all of the containers. To run the composed containers in the background, use the `-d` argument.
@@ -72,6 +74,7 @@ _If you're missing code coverage, open `coverage.html` in the root of the projec
 ## Gotchas
 
 - ES6 Template Strings are not supported by esprima which means you can't generate coverage reports which means `npm test` won't pass.
+- Be sure to include the external port at the end of the domain in your `.env` file if running behind a load balancer<br>(i.e. `DOMAIN=dev.jsperf.com:80`).
 
 ### Adding new dependencies
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ web:
     PORT: 3000
     SERVICE_3000_CHECK_HTTP: '/health'
     SERVICE_3000_CHECK_INTERVAL: '1s'
+  volumes:
+    - .:/code
 db:
   image: mysql
   volumes_from:
@@ -29,6 +31,10 @@ lb:
     - consul
   ports:
     - '80:80'
+  volumes:
+    - ./docker/nginx.conf:/etc/consul-templates/nginx.conf:ro
+    - ./docker/consul-template.service:/etc/service/consul-template/run:ro
+    - ./docker/nginx.service:/etc/service/nginx/run:ro
 consul:
   image: gliderlabs/consul-server:0.6
   command: [-bootstrap, -advertise, 127.0.0.1, -client, 0.0.0.0]

--- a/docker/Dockerfile-lb
+++ b/docker/Dockerfile-lb
@@ -7,9 +7,11 @@ RUN apk-install nginx curl runit@testing
 RUN curl -L -o /tmp/consul-template.zip http://releases.hashicorp.com/consul-template/0.12.0/consul-template_0.12.0_linux_amd64.zip
 RUN unzip /tmp/consul-template.zip -d /usr/local/bin
 
+RUN mkdir -p /run/nginx
+RUN touch /run/nginx/nginx.pid
+
 ADD nginx.service /etc/service/nginx/run
 ADD consul-template.service /etc/service/consul-template/run
-
 ADD nginx.conf /etc/consul-templates/nginx.conf
 
 CMD ["/sbin/runsvdir", "/etc/service"]


### PR DESCRIPTION
### Description

1. Fixes the following error on jsperfcom_lb container:

	```shell
	nginx: [emerg] open() "/run/nginx/nginx.pid" failed (2: No such file or directory)
	```
2. Mounts service config files as volumes on jsperfcom_lb container for easier debugging.
3. Mounts project root as a volume so changes are reflected on the jsperfcom_web container in real time.
4. Add note to README regarding how to prevent redirects from being sent to container port (as opposed to load balancer port) when running jsperf app on docker.
