### PR TITLE
Fix nginx pid not found

### DIFF
--- a/docker/Dockerfile-lb
+++ b/docker/Dockerfile-lb
@@ -10,6 +10,7 @@ RUN unzip /tmp/consul-template.zip -d /usr/local/bin
 ADD nginx.service /etc/service/nginx/run
 ADD consul-template.service /etc/service/consul-template/run
 
+RUN mkdir /run/nginx
 ADD nginx.conf /etc/consul-templates/nginx.conf
 
 CMD ["/sbin/runsvdir", "/etc/service"]


### PR DESCRIPTION
See [latest image run nginx problems](https://github.com/gliderlabs/docker-alpine/issues/185)

docker-compose log error:
`nginx: [emerg] open() "/run/nginx/nginx.pid" failed (2: No such file or directory)`