### PR TITLE
add /publish endpoint to make tests visible to the public

### DIFF
--- a/server/services/pages.js
+++ b/server/services/pages.js
@@ -155,5 +155,17 @@ module.exports = {
         values.push(revisions);
         return values;
       });
+  },
+
+  publish: function (pageID) {
+    const now = new Date();
+    const modify = {
+      visible: 'y',
+      updated: now,
+      published: now
+    };
+
+    debug('publish', pageID, modify);
+    return pagesRepo.updateById(modify, pageID);
   }
 };

--- a/server/web/test/index.hbs
+++ b/server/web/test/index.hbs
@@ -17,7 +17,7 @@
   {{/compare}}
 
   {{#if noIndex}}
-    <strong><a href="/{{page.slug}}{{#compare 1 page.revision}}/{{page.revision}}{{/compare}}/publish">Not published yet!</a></strong>
+    <strong><a href="/{{page.slug}}/{{page.revision}}/publish">Not published yet!</a></strong>
     &middot;
     <a href="/{{page.slug}}{{#compare 1 page.revision}}/{{page.revision}}{{/compare}}/edit">Edit</a>
   {{/if}}

--- a/test/server/services/pages.js
+++ b/test/server/services/pages.js
@@ -648,4 +648,21 @@ lab.experiment('Pages Service', function () {
         });
     });
   });
+
+  lab.experiment('publish', () => {
+    lab.test('updates page to be visible', (done) => {
+      pagesRepoStub.updateById = s.stub().returns(Promise.resolve());
+
+      pages.publish(1)
+        .then(() => {
+          Code.expect(pagesRepoStub.updateById.args[0][0]).to.include({
+            visible: 'y'
+          });
+          Code.expect(pagesRepoStub.updateById.args[0][1]).to.equal(1);
+
+          done();
+        })
+        .catch(done);
+    });
+  });
 });


### PR DESCRIPTION
closes #9 

allows owner or admin to click on link when viewing test to publish it