### PR TITLE
Have the MySQL-host as a ENV-variable

### DIFF
--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -10,7 +10,7 @@ module.exports = {
     }
     return new Promise(function (resolve, reject) {
       var conn = mysql.createConnection({
-        host: 'db',
+        host: process.env.DB_ENV_MYSQL_HOST || 'db',
         port: 3306,
         user: process.env.DB_ENV_MYSQL_USER,
         password: process.env.DB_ENV_MYSQL_PASSWORD,


### PR DESCRIPTION
I know it's rather late in the process, but having the MySQL-host as a env-variable would make it possible to get a running local dev environment without docker and without having to change any of the code. In this PR, it gracefully falls back to using `db` as the default hostname in case no other is specified.

This would make it possible to start jsPerf using:
`DB_ENV_MYSQL_PASSWORD=password DB_ENV_MYSQL_DATABASE=jsperf DB_ENV_MYSQL_USER=jsperf DB_ENV_MYSQL_HOST=localhost npm start`