### PR TITLE
get env vars from file instead of redefining in script

### DIFF
--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -9,18 +9,10 @@ for service in $services; do
   docker rm $service
   docker run -d --name 'jsperfcom_web_'$timestamp'_'$enum -P \
     --link jsperfcom_db_1:db \
-    --env DOMAIN=$DOMAIN \
-    --env SCHEME=$SCHEME \
-    --env PORT=3000 \
-    --env ADMIN_EMAIL=$ADMIN_EMAIL \
-    --env BROWSERSCOPE=$BROWSERSCOPE \
-    --env BELL_COOKIE_PASS=$BELL_COOKIE_PASS \
-    --env COOKIE_PASS=$COOKIE_PASS \
+    --env-file /etc/environment
     --env DB_ENV_MYSQL_DATABASE=jsperf \
     --env DB_ENV_MYSQL_PASSWORD=$MYSQL_PASSWORD \
     --env DB_ENV_MYSQL_USER=jsperf \
-    --env GITHUB_CLIENT_ID=$GITHUB_CLIENT_ID \
-    --env GITHUB_CLIENT_SECRET=$GITHUB_CLIENT_SECRET \
     --env SERVICE_3000_CHECK_HTTP=/health \
     --env SERVICE_3000_CHECK_INTERVAL=1s \
     --env SERVICE_NAME=jsperfcom_web \


### PR DESCRIPTION
alternate to #122 

this approach would allow us to change values in `/etc/environment` and re-run the deploy script instead of needing to keep env vars in the deploy script up to date 