### PR TITLE
runit is now in the @community repository

### DIFF
--- a/docker/Dockerfile-lb
+++ b/docker/Dockerfile-lb
@@ -1,8 +1,8 @@
 FROM gliderlabs/alpine:3.4
 
-RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN echo "@community http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 
-RUN apk-install nginx curl runit@testing
+RUN apk-install nginx curl runit@community
 
 RUN curl -L -o /tmp/consul-template.zip http://releases.hashicorp.com/consul-template/0.12.0/consul-template_0.12.0_linux_amd64.zip
 RUN unzip /tmp/consul-template.zip -d /usr/local/bin


### PR DESCRIPTION
runit is no longer available from @testing, but can be accessed via @community