### PR TITLE
Fix accidental caching

### DIFF
--- a/server/web/home/index.js
+++ b/server/web/home/index.js
@@ -1,6 +1,6 @@
 var _assign = require('lodash.assign');
 var Joi = require('joi');
-const Hoek = require('hoek');
+
 const defaults = require('../../lib/defaults');
 const schema = require('../../lib/schema');
 var pagesService = require('../../services/pages');
@@ -21,8 +21,7 @@ exports.register = function (server, options, next) {
       if (request.auth.isAuthenticated) {
         authorized = true;
       }
-
-      reply.view('home/index', Hoek.applyToDefaults(defaults.testPageContext, {
+      reply.view('home/index', _assign({}, defaults.testPageContext, {
         test: [defaults.test, defaults.test],
         authorized: authorized
       }));

--- a/server/web/home/index.js
+++ b/server/web/home/index.js
@@ -1,6 +1,6 @@
 var _assign = require('lodash.assign');
 var Joi = require('joi');
-
+const Hoek = require('hoek');
 const defaults = require('../../lib/defaults');
 const schema = require('../../lib/schema');
 var pagesService = require('../../services/pages');
@@ -22,7 +22,7 @@ exports.register = function (server, options, next) {
         authorized = true;
       }
 
-      reply.view('home/index', _assign(defaults.testPageContext, {
+      reply.view('home/index', Hoek.applyToDefaults(defaults.testPageContext, {
         test: [defaults.test, defaults.test],
         authorized: authorized
       }));
@@ -40,7 +40,7 @@ exports.register = function (server, options, next) {
         if (errObj.message) {
           errObj.genError = errObj.message;
         }
-        reply.view('home/index', _assign(defaults.testPageContext, request.payload, {authorized: true}, errObj)).code(400);
+        reply.view('home/index', _assign({}, defaults.testPageContext, request.payload, {authorized: true}, errObj)).code(400);
       };
 
       Joi.validate(request.payload, schema.testPage, function (er, pageWithTests) {


### PR DESCRIPTION
@mathiasbynens caught an issue where a user would see details from another session. See: https://i.imgur.com/XJqs3DT.png

The root cause is that _assign from lodash mutates. "Note: This method mutates object".
