### PR TITLE
Pass actual highlight.js version to header template

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -8,7 +8,7 @@ var criteria = {
 
 var visionaryContextDefault = {
   cssFile: 'main.css',
-  hljsCssVer: require('./package.json').dependencies['highlight.js'],
+  hljsCssVer: require('highlight.js/package.json').version,
   scheme: config.get('/scheme'),
   domain: config.get('/domain')
 };


### PR DESCRIPTION
Get the version number from highlight.js' own `package.json` instead of using jsPerf's dependencies. The latter causes the browser to request version `^9.8.0` from cdnjs, which doesn't understand semver ranges.