### PR TITLE
show 'add code snippet' button on edit page

### DIFF
--- a/server/lib/defaults.js
+++ b/server/lib/defaults.js
@@ -29,12 +29,6 @@ exports.test = {
 };
 
 exports.testPageContext = {
-  home: true,
-  showAtom: {
-    slug: 'browse'
-  },
-  jsClass: true,
-  mainJS: true,
   mediumTextLength: MEDIUM_TEXT_LENGTH,
   titleError: null,
   slugError: null,

--- a/server/web/edit/index.hbs
+++ b/server/web/edit/index.hbs
@@ -117,7 +117,7 @@ This edit will create a new revision.
       <h3>Code snippets to compare</h3>
       {{#each page.test}}
       <fieldset>
-        <h4>Test {{@index}}</h4>
+        <h4>Code snippet {{inc @index}}</h4>
         <div>
           <label for="test[{{@index}}][title]">Title </label>
           <input type="text" name="test[{{@index}}][title]" id="test[{{@index}}][title]" value="{{title}}">

--- a/server/web/edit/index.js
+++ b/server/web/edit/index.js
@@ -29,6 +29,7 @@ exports.register = function (server, options, next) {
           reply.view('edit/index', {
             headTitle: page.title,
             benchmark: false,
+            mainJS: true,
             showAtom: {
               slug: request.path.slice(1) // remove slash
             },
@@ -66,8 +67,14 @@ exports.register = function (server, options, next) {
         Hoek.merge(page, errObj);
         reply.view('edit/index', {
           headTitle: page.title,
+          benchmark: false,
+          mainJS: true,
+          showAtom: {
+            slug: request.path.slice(1) // remove slash
+          },
+          jsClass: true,
           page: page,
-          authorized: true
+          authorized: request.auth.isAuthenticated
         }).code(400);
       };
 

--- a/server/web/home/index.js
+++ b/server/web/home/index.js
@@ -16,14 +16,15 @@ exports.register = function (server, options, next) {
       }
     },
     handler: function (request, reply) {
-      var authorized = false;
-
-      if (request.auth.isAuthenticated) {
-        authorized = true;
-      }
       reply.view('home/index', _assign({}, defaults.testPageContext, {
+        home: true,
+        showAtom: {
+          slug: 'browse'
+        },
+        jsClass: true,
+        mainJS: true,
         test: [defaults.test, defaults.test],
-        authorized: authorized
+        authorized: request.auth.isAuthenticated
       }));
     }
   });
@@ -39,7 +40,15 @@ exports.register = function (server, options, next) {
         if (errObj.message) {
           errObj.genError = errObj.message;
         }
-        reply.view('home/index', _assign({}, defaults.testPageContext, request.payload, {authorized: true}, errObj)).code(400);
+        reply.view('home/index', _assign({}, defaults.testPageContext, request.payload, {
+          home: true,
+          showAtom: {
+            slug: 'browse'
+          },
+          jsClass: true,
+          mainJS: true,
+          authorized: request.auth.isAuthenticated
+        }, errObj)).code(400);
       };
 
       Joi.validate(request.payload, schema.testPage, function (er, pageWithTests) {

--- a/test/unit/server/web/edit/index.js
+++ b/test/unit/server/web/edit/index.js
@@ -127,6 +127,7 @@ lab.experiment('GET', function () {
     server.inject(request, function (response) {
       Code.expect(response.statusCode).to.equal(200);
       Code.expect(response.payload).to.include('<title>Oh Yea · jsPerf</title>');
+      Code.expect(response.payload).to.include('<script src="/public/_js/main.');
 
       done();
     });

--- a/test/unit/server/web/home/index.js
+++ b/test/unit/server/web/home/index.js
@@ -104,6 +104,7 @@ lab.experiment('home', function () {
 
       server.inject(request, function (response) {
         Code.expect(response.result).to.include('Save test case');
+        Code.expect(response.payload).to.include('<script src="/public/_js/main.');
 
         done();
       });


### PR DESCRIPTION
mostly fixes #247 

1. you can now add more code snippets 🎆 
2. once you add a code snippet, there's no way to remove it 😬 

the broken logic was in the footer due to missing template variables. needed `benchmark === false && mainJS === true` to get jQuery and the JS that adds button client side