### PR TITLE
Fixes "Not all tests inserted" errors

### DIFF
--- a/server/lib/schema.js
+++ b/server/lib/schema.js
@@ -24,7 +24,8 @@ exports.testPage = Joi.object().keys({
     title: Joi.string().required().trim().min(1).max(255),
     defer: Joi.string().default('n').valid('y', 'n'),
     code: Joi.string().required().trim().min(1).max(defaults.mediumTextLength),
-    testID: Joi.number().integer() // optional. only present when editing
+    testID: Joi.number().integer(), // optional. only present when editing
+    pageID: Joi.number().integer()  // optional. only present when editing
   }))
 });
 

--- a/server/repositories/tests.js
+++ b/server/repositories/tests.js
@@ -33,9 +33,10 @@ exports.register = function (server, options, next) {
         if (update && test.testID) {
           queries.push(db.genericQuery(`DELETE FROM tests WHERE pageID = ${pageID} AND testID = ${test.testID}`));
         }
+        // otherwise just skip the test
       } else {
         // Update test
-        if (test.testID) {
+        if (test.testID && test.pageID === pageID) {
           queries.push(db.genericQuery(`UPDATE tests SET title = ${db.escape(test.title)}, defer =  ${db.escape(test.defer)} , code =  ${db.escape(test.code)} WHERE pageID = ${pageID} AND testID = ${test.testID}`));
         } else {
           queries.push(db.genericQuery(`INSERT INTO ?? (??) VALUES (${pageID}, ${db.escape(test.title)}, ${db.escape(test.defer)}, ${db.escape(test.code)})`, [table, columns]));

--- a/server/web/edit/index.hbs
+++ b/server/web/edit/index.hbs
@@ -134,6 +134,7 @@ This edit will create a new revision.
           </label>
           <textarea name="test[{{@index}}][code]" id="test[{{@index}}][code]" class="code-js" maxlength="{{mediumTextLength}}">{{code}}</textarea>
           <input type="hidden" name="test[{{@index}}][testID]" value="{{testID}}">
+          <input type="hidden" name="test[{{@index}}][pageID]" value="{{pageID}}">
           {{error codeError tag="p"}}
         </div>
       </fieldset>

--- a/test/unit/server/repositories/tests.js
+++ b/test/unit/server/repositories/tests.js
@@ -149,8 +149,11 @@ lab.experiment('Tests Repository', function () {
         .then(results => {
           let call1 = genericQueryStub.getCall(0).args;
           call1 = Hoek.flatten(call1).join(',');
+          let call2 = genericQueryStub.getCall(1).args;
+          call2 = Hoek.flatten(call2).join(',');
 
           Code.expect(call1).to.equal('INSERT INTO ?? (??) VALUES (1, `t1`, `n`, `a = 1`),tests,pageID,title,defer,code');
+          Code.expect(call2).to.equal('INSERT INTO ?? (??) VALUES (1, `t2`, `n`, `a = 2`),tests,pageID,title,defer,code');
           done();
         });
     });
@@ -171,7 +174,9 @@ lab.experiment('Tests Repository', function () {
       genericQueryStub.returns(Promise.resolve({ affectedRows: 1 }));
       let tClone = Hoek.clone(t);
       tClone[0].testID = 123;
+      tClone[0].pageID = 1;
       tClone[1].testID = 321;
+      tClone[1].pageID = 1;
       tests.bulkUpdate(pageID, tClone, false)
         .then(results => {
           let call1 = genericQueryStub.getCall(0).args;
@@ -179,8 +184,8 @@ lab.experiment('Tests Repository', function () {
           let call2 = genericQueryStub.getCall(1).args;
           call2 = Hoek.flatten(call2).join(',');
 
-          Code.expect(call2).to.equal('UPDATE tests SET title = `t2`, defer =  `n` , code =  `a = 2` WHERE pageID = 1 AND testID = 321');
           Code.expect(call1).to.equal('UPDATE tests SET title = `t1`, defer =  `n` , code =  `a = 1` WHERE pageID = 1 AND testID = 123');
+          Code.expect(call2).to.equal('UPDATE tests SET title = `t2`, defer =  `n` , code =  `a = 2` WHERE pageID = 1 AND testID = 321');
           done();
         });
     });
@@ -189,7 +194,9 @@ lab.experiment('Tests Repository', function () {
       genericQueryStub.returns(Promise.resolve({ affectedRows: 1 }));
       let tClone = Hoek.clone(t);
       tClone[0].testID = 123;
+      tClone[0].pageID = 1;
       tClone[1].testID = 321;
+      tClone[1].pageID = 2;
       delete tClone[0].code;
       delete tClone[0].title;
       delete tClone[1].code;


### PR DESCRIPTION
This PR adds the current revision's pageID to forms for existing test cases in web/edit/index.hbs, which is then checked for equality before trying to run an UPDATE query in repositories/tests.js. This is necessary because, when creating a new revision, the UPDATE query references the new revision's pageID (instead of the old one's) in its WHERE clause, which makes it always evaluate to false, in turn resulting in "Not all tests inserted" errors as reported in https://github.com/jsperf/jsperf.com/issues/236. In this case, it now falls back to an INSERT query.

The PR assumes that, if the pageID of the currently processing revision differs from the one included in the post request, a new test case needs to be created for the new revision, regardless of whether it has been edited or not, and that the previous revision's test case remains untouched.

Tests have been updated accordingly.