### PR TITLE
Add Opbeat as a sponsor

### DIFF
--- a/templates/partials/footer.hbs
+++ b/templates/partials/footer.hbs
@@ -4,6 +4,7 @@
     <ul>
       <li>
         <h4>Sponsors</h4>
+        <p>Supported by <a href="https://opbeat.com/">Opbeat</a></p>
         <p>Hosting generously provided by <a href="https://m.do.co/c/b426e15331e8">DigitalOcean</a> and <a href="https://zeit.co/">Zeit</a></p>
 
         <p><a href="/sponsor">Learn how to become a sponsor</a></p>


### PR DESCRIPTION
https://opbeat.com/ provides performance monitoring with framework support, and is built for JavaScript developers.