### PR TITLE
fixed undefined browserscope scheme

### DIFF
--- a/config.js
+++ b/config.js
@@ -47,6 +47,7 @@ var config = {
   env: process.env.NODE_ENV,
   port: process.env.PORT,
   domain: process.env.DOMAIN,
+  scheme: process.env.SCHEME,
   auth: {
     oauth: {
       secure: {


### PR DESCRIPTION
Using default (commented out) or custom values for SCHEME in `.env` resulted faulty query strings from `browserscope.js`

api_key=xxxxxxxxxxxxxxxxxxxxxxxx&name=First%20Test&description=This%20is%20just%20a%20test%20case&url=**undefined**%3A%2F%2Flocalhost%2Ffirst-test

Adding `scheme: process.env.SCHEME` to `var config = {...` in config.js corrected the issue. 

If there's a more elegant fix (I couldn't figure out what the `exports.get = function...` does) please let me know.