### PR TITLE
fix default config values from process.env

### DIFF
--- a/config.js
+++ b/config.js
@@ -39,14 +39,15 @@ var Confidence = require('confidence');
 var _assign = require('lodash.assign');
 
 var criteria = {
-  scheme: process.env.SCHEME
+  scheme: result.value.SCHEME
 };
 
 var config = {
   $meta: 'jsPerf.com',
-  env: process.env.NODE_ENV,
-  port: process.env.PORT,
-  domain: process.env.DOMAIN,
+  env: result.value.NODE_ENV,
+  port: result.value.PORT,
+  domain: result.value.DOMAIN,
+  scheme: result.value.SCHEME,
   auth: {
     oauth: {
       secure: {
@@ -55,14 +56,14 @@ var config = {
         $default: false
       },
       github: {
-        secret: process.env.GITHUB_CLIENT_SECRET,
-        id: process.env.GITHUB_CLIENT_ID,
-        callback: process.env.GITHUB_CALLBACK
+        secret: result.value.GITHUB_CLIENT_SECRET,
+        id: result.value.GITHUB_CLIENT_ID,
+        callback: result.value.GITHUB_CALLBACK
       },
-      cookiePass: process.env.BELL_COOKIE_PASS
+      cookiePass: result.value.BELL_COOKIE_PASS
     },
     session: {
-      pass: process.env.COOKIE_PASS,
+      pass: result.value.COOKIE_PASS,
       name: 'sid-jsperf',
       secure: {
         $filter: 'scheme',
@@ -71,17 +72,17 @@ var config = {
       }
     }
   },
-  browserscope: process.env.BROWSERSCOPE,
+  browserscope: result.value.BROWSERSCOPE,
   mysql: {
-    host: process.env.MYSQL_HOST,
-    port: process.env.MYSQL_PORT,
-    user: process.env.MYSQL_USER,
-    pass: process.env.MYSQL_PASSWORD,
-    db: process.env.MYSQL_DATABASE
+    host: result.value.MYSQL_HOST,
+    port: result.value.MYSQL_PORT,
+    user: result.value.MYSQL_USER,
+    pass: result.value.MYSQL_PASSWORD,
+    db: result.value.MYSQL_DATABASE
   },
   loggly: {
-    token: process.env.LOGGLY_TOKEN,
-    subdomain: process.env.LOGGLY_SUBDOMAIN
+    token: result.value.LOGGLY_TOKEN,
+    subdomain: result.value.LOGGLY_SUBDOMAIN
   }
 };
 

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -2,11 +2,7 @@ const Lab = require('lab');
 const Code = require('code');
 const Proxyquire = require('proxyquire').noPreserveCache();
 
-const Config = Proxyquire('../../config', {
-  'joi': {
-    validate: () => ({})
-  }
-});
+const Config = require('../../config');
 
 const lab = exports.lab = Lab.script();
 
@@ -19,6 +15,33 @@ lab.experiment('Config', function () {
   lab.test('it gets config meta data', function (done) {
     Code.expect(Config.meta('/')).to.match(/jsPerf/i);
     done();
+  });
+
+  lab.experiment('defaults', () => {
+    lab.test('it gets scheme', (done) => {
+      Code.expect(Config.get('/scheme')).to.equal('http');
+      done();
+    });
+
+    lab.test('it gets port', (done) => {
+      Code.expect(Config.get('/port')).to.equal(3000);
+      done();
+    });
+
+    lab.test('it gets domain', (done) => {
+      Code.expect(Config.get('/domain')).to.equal('localhost');
+      done();
+    });
+
+    lab.test('it gets mysql host', (done) => {
+      Code.expect(Config.get('/mysql/host')).to.equal('localhost');
+      done();
+    });
+
+    lab.test('it gets mysql port', (done) => {
+      Code.expect(Config.get('/mysql/port')).to.equal(3306);
+      done();
+    });
   });
 
   lab.experiment('Cookies', function () {

--- a/test/unit/config.js
+++ b/test/unit/config.js
@@ -2,7 +2,26 @@ const Lab = require('lab');
 const Code = require('code');
 const Proxyquire = require('proxyquire').noPreserveCache();
 
-const Config = require('../../config');
+const Config = Proxyquire('../../config', {
+  'dotenv': {
+    config: () => {
+      // set environment variables that should be in .env file
+      [
+        'GITHUB_CLIENT_SECRET',
+        'GITHUB_CLIENT_ID',
+        'GITHUB_CALLBACK',
+        'BELL_COOKIE_PASS',
+        'COOKIE_PASS',
+        'BROWSERSCOPE',
+        'MYSQL_USER',
+        'MYSQL_PASSWORD',
+        'MYSQL_DATABASE'
+      ].map((k) => {
+        process.env[k] = k;
+      });
+    }
+  }
+});
 
 const lab = exports.lab = Lab.script();
 


### PR DESCRIPTION
closes #346 

validating `process.env` is good. using the defaults we set is better.

this will also fix URLs registered with Browserscope