### PR TITLE
Fix loading of browserscope visualization

### DIFF
--- a/public/_js/test.js
+++ b/public/_js/test.js
@@ -22693,6 +22693,27 @@
     var name = 'bs-chart-frame',
         iframe = createElement('iframe', name);
 
+    addListener(iframe, 'load', function () { 
+        // the element the charts are inserted into
+        me.container = query('#bs-chart', idoc)[0];
+
+        if (!me.container) return;
+
+        // Browserscope's UA div is inserted before an element with the id of "bs-ua-script"
+        loadScript('https://www.browserscope.org/ua?o=js', me.container).id = 'bs-ua-script';
+
+        // the "autoload" string is created following the guide at
+        // https://developers.google.com/loader/?hl=en#auto-loading
+        setTimeout(function() { loadScript('https://www.google.com/jsapi?autoload=' + encodeURIComponent('{' +
+          'modules:[{' +
+            'name:"visualization",' +
+            'version:1,' +
+            'packages:["corechart","table"],' +
+            'callback:ui.browserscope.load' +
+          '}]' +
+        '}'), idoc); }, 2000);
+    });
+
     iframe.id = name;
     iframe.frameBorder = 0;
     iframe.scrolling = 'no';
@@ -22733,26 +22754,6 @@
 
     // the frame window of the charts
     me.chartWindow = iwin;
-
-    // ensure that content in iframe is processed by executing on next tick
-    setTimeout(function() {
-      // the element the charts are inserted into
-      me.container = query('#bs-chart', idoc)[0];
-
-      // Browserscope's UA div is inserted before an element with the id of "bs-ua-script"
-      loadScript('https://www.browserscope.org/ua?o=js', me.container).id = 'bs-ua-script';
-
-      // the "autoload" string is created following the guide at
-      // https://developers.google.com/loader/?hl=en#auto-loading
-      setTimeout(function() { loadScript('https://www.google.com/jsapi?autoload=' + encodeURIComponent('{' +
-        'modules:[{' +
-          'name:"visualization",' +
-          'version:1,' +
-          'packages:["corechart","table"],' +
-          'callback:ui.browserscope.load' +
-        '}]' +
-      '}'), idoc); }, 2000);
-    }, 1);
   });
 
   // hide the chart while benchmarks are running


### PR DESCRIPTION
This changes the setTimeout with timeout 1, to a proper `load`-Event listener. The problem in #235 is that for some reason in chrome on [this line](https://github.com/jsperf/jsperf.com/blob/master/public/_js/test.js#L22740) the iframe is still `loading`, which means the query fails and the container is still null.
I changed this to use the load event from the iframe. It occurs twice, the first time before the write the second one afterwards. That is why I added the check if the container was found.

I tested on mac with latest chrome, ff, safari and on browserstack IE11/Win7 and they all work. IE8, IE9, IE10 on Win7 also display the visualizations, but running the tests fails and on page load there are also some js errors, but unrelated to this change.

Fixes #235