### PR TITLE
Fix issue with bad updates causing disappearing tests

### DIFF
--- a/server/repositories/tests.js
+++ b/server/repositories/tests.js
@@ -38,7 +38,7 @@ exports.register = function (server, options, next) {
         }
         // ... otherwise skip over the test
       } else {
-        if (test.testID) {
+        if (isOwn && test.testID) {
           queries.push(db.genericQuery(`UPDATE ?? SET title = ${db.escape(test.title)}, defer =  ${db.escape(test.defer)} , code =  ${db.escape(test.code)} WHERE pageID = ${pageID} AND testID = ${test.testID}`, [table]));
         } else {
           queries.push(db.genericQuery(`INSERT INTO ?? (??) VALUES (${pageID}, ${db.escape(test.title)}, ${db.escape(test.defer)}, ${db.escape(test.code)})`, [table, columns]));


### PR DESCRIPTION
Fixes #236

Pretty much similar to #414, but with an added test to show the issue.

Based on what @mathiasbynens said in that PR https://github.com/jsperf/jsperf.com/pull/414#issuecomment-317957031

It seems like the original fix in #414 was correct. I have also written a test that shows the correct action.

If you are the owner of the test (aka you own the 1st revision), only you (with the `isOwn` flag set to true) should be able to "update" an existing test. Otherwise you are not the owner and you should only be inserting your test cases into a revision.

The reason for all the tests having "empty" test cases is because the code would fall into the UPDATE sql statement every single time regardless of whether you're the actual owner or not because each test _always_ passes a testID unless a new test case is added to your revision of the test. 
E.g. every test has the two basic test cases, and so if you try to create a new revision and only edit those 2 test cases, you'll get a blank test revision. If you add an extra test case in that revision, then that one won't have a `testID` and thus will make an INSERT call and this new revision will only have the new test case.

The additional test case shows that if you are the owner, you make updates if the test cases exist, and if you are not the owner you only make inserts.