### PR TITLE
Adding X-UA-Compatible in the head

### DIFF
--- a/templates/partials/header.hbs
+++ b/templates/partials/header.hbs
@@ -1,6 +1,6 @@
 <head>
   <meta charset="utf-8">
-
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   {{#if headTitle}}
     <title>{{headTitle}} · jsPerf</title>
   {{else}}


### PR DESCRIPTION
X-UA-Compatible permits to make sure IE uses the last version of its engine. Right now if I visit jsperf.com from IE at my office, IE will use IE7 rendering engine instead of IE11 (because of "Compatibility View"). Adding X-UA-Compatible should fix this issue.