### PR TITLE
Don’t load Font Awesome

### DIFF
--- a/templates/partials/header.hbs
+++ b/templates/partials/header.hbs
@@ -17,7 +17,6 @@
 
   {{#if home}}
     <meta name="description" content="A performance playground for JavaScript developers. Easily create and share test cases and run cross-browser benchmarks to find out which code snippet is most efficient.">
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
   {{/if}}
 
   {{#if showAtom}}


### PR DESCRIPTION
This seems to have been added by mistake? The original jsPerf didn’t have any CSS other than the `main.css`.