### PR TITLE
Remove legacy `alias` and `name` from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "name": "jsPerf",
   "version": 2,
   "public": true,
   "builds": [
@@ -14,7 +13,6 @@
       "dest": "server.js"
     }
   ],
-  "alias": ["jsperf.com"],
   "env": {
     "SCHEME": "https",
     "DOMAIN": "jsperf.com",


### PR DESCRIPTION
Also curious to see if a redeployment will fix the current errors